### PR TITLE
Add chopring support.

### DIFF
--- a/ext_libs/chopring.py
+++ b/ext_libs/chopring.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2013 The MITRE Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+from collections import deque
+
+
+class chopring(deque):
+    """
+    A chopring is a double ended queue.
+
+    Chopring supports pretty printing, the ability to
+    get a slice of the queue, and of course all of the functionality
+    in collections.deque.
+
+    """
+
+    def __init__(self, size=1024 * 10, iterable=()):
+        super(chopring, self).__init__(iterable, size)
+
+    def __str__(self):
+        return ''.join(self)
+
+    def __getslice__(self, i, j):
+        return ''.join(self)[i:j]


### PR DESCRIPTION
Chopring is a simple double ended queue based upon
Python's deque. The days of buffering huge streams in memory
are over. You can use chopring to buffer a configurable sized
blob, and operate over it in your chopshop modules.
