### PR TITLE
fix sending abort signal to chopshop

### DIFF
--- a/chopshop
+++ b/chopshop
@@ -79,8 +79,6 @@ def signal_handler(signal, frame):
         try:
             CSD.debug_out("Signal Caught\n")
             choplib.stop()
-            # when in longrun, surgeon needs special handling
-            os.kill(choplib.nidsp.pid, signal)
 
             chopui.stop()
             chopui.join()
@@ -94,8 +92,7 @@ def signal_handler(signal, frame):
 
 # send signal to finish processing data so far and exit
 def abrt_signal_handler(signal, frame):
-    os.kill(choplib.surgeon.p.pid, signal)
-    os.kill(choplib.nidsp.pid, signal)
+    choplib.abort()
 
 
 signal.signal(signal.SIGINT, signal_handler)

--- a/shop/ChopNids.py
+++ b/shop/ChopNids.py
@@ -351,9 +351,7 @@ class ChopCore(Thread):
             nids.register_udp(handleUdpDatagrams)
             nids.register_ip(handleIpPackets)
 
-            while(True): #This overall while prevents exceptions from halting the long running reading
-                if self.stopped:
-                    break
+            while(not self.stopped): #This overall while prevents exceptions from halting the long running reading
                 try:
                     if options['longrun']: #long running don't stop until the proces is killed externally
                         while not self.stopped:
@@ -366,11 +364,10 @@ class ChopCore(Thread):
                             pass
                     self.stopped = True #Force it to true and exit
                 except Exception, e:
+                    chop.prnt("Error processing packets", e)
                     if not options['longrun']:
                         self.stopped = True #Force it to true and exit
-                    chop.prnt("Error processing packets", e)
-                    raise
-
+                        raise # only raise if not in longrun
 
         chop.prettyprnt("RED", "Shutting Down Modules ...")
 


### PR DESCRIPTION
It seems that sending signals is interrupting pcap i/o causing exceptions when amount of data read does not match the amount of data sent. Replacing signals with interprocess communication.

chopshop
- removed passing signals to child processes
- call functions in ChopLib to stop/abort

ChopLib.py
- removed signal handling
- added functions to handle putting abort signal to nids and surgeon processes

ChopNids.py
- moved raise so only called if not longrun

ChopSurgeon.py
- removed signal handling
- added queue to receive data
- added queue reading to react when sent stop or abort
