### PR TITLE
added "strict" option to b64decode

### DIFF
--- a/ext_libs/b64.py
+++ b/ext_libs/b64.py
@@ -23,17 +23,74 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-# Decode the given string with the given alphabet
-def b64decode(s, alpha):
-    output = ""
-    x = 0
-    while x <= len(s) - 4:
-        out = (alpha.find(s[x]) & 0x3f) << 18
-        out += (alpha.find(s[x+1]) & 0x3f) << 12
-        out += (alpha.find(s[x+2]) & 0x3f) << 6
-        out += (alpha.find(s[x+3]) & 0x3f)
-        output += chr((out & 0xff0000) >> 16) + chr((out & 0x00ff00) >> 8) + chr(out & 0x0000ff)
-        x += 4
-    return output
+import base64
+import string
 
-
+def b64decode(s, alpha='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/', padbyte='=', strict=True):
+    '''
+    Decode the given string with the given alphabet.
+    If strict==False, tries modifying the input string in the following order:
+    1. add pad byte(s) to end
+    2. remove non-alphabet bytes at end
+    3. remove 1-4 bytes at end (to make strlen % 4 == 0)
+    4. remove non-alphabet bytes at beginning
+    '''
+    b64_alpha = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    b64_pad = '='
+    over = len(s) % 4
+    if not strict:
+        if over == 1:
+            # three-character padding at end is worthless/illegal, so just remove one char
+            s = s[:-1]
+        else:
+            # try padding end
+            s += padbyte * (4 - over)
+    if alpha != b64_alpha or padbyte != b64_pad:
+        # translate, if needed
+        translator = string.maketrans(alpha+padbyte,b64_alpha+b64_pad)
+        #print "DEBUG: before:", s
+        s = s.translate(translator)
+        #print "DEBUG: after:", s
+    if strict:
+        return base64.b64decode(s)
+    # not strict mode, so try a few things...
+    try:
+        return base64.b64decode(s)
+    except TypeError:
+        pass
+    # check for illegal bytes at end and remove them
+    i = 1
+    c = s[-i]
+    while c not in b64_alpha:
+        i+=1
+        c = s[-i]
+    if i > 1:
+        # illegal bytes found, remove 'em!
+        i -= 1
+        s = s[:-i]
+        # add padding
+        if len(s) % 4 != 0:
+            s += b64_pad * (4 - (len(s) % 4))
+        try:
+            return base64.b64decode(s)
+        except TypeError:
+            pass
+    else:
+        # try removing the "over" bytes
+        try:
+            return base64.b64decode(s[:-4])
+        except TypeError:
+            pass
+    # try removing bad chars from start of string
+    i = 0
+    c = s[i]
+    while c not in b64_alpha:
+        i+=1
+        c = s[i]
+    if i > 1:
+        # illegal bytes found, remove 'em!
+        s = s[i:]
+        # add padding
+        if len(s) % 4 != 0:
+            s += b64_pad * (4 - (len(s) % 4))
+        return base64.b64decode(s)


### PR DESCRIPTION
Argument for padding character.
Argument to specify "strict" decoding or not (default: Yes)
- if strict=True, exception like base64 module on bad input
- if strict=False, try the following to "fix" the input:
  1. add pad byte(s) to end
  2. remove non-alphabet bytes at end
  3. remove 1-4 bytes at end (to make strlen % 4 == 0)
  4. remove non-alphabet bytes at beginning
