### PR TITLE
Check against basestring.

### DIFF
--- a/shop/ChopLib.py
+++ b/shop/ChopLib.py
@@ -117,7 +117,7 @@ class ChopLib(Thread):
 
     @mod_dir.setter
     def mod_dir(self, v):
-        if isinstance(v, str):
+        if isinstance(v, basestring):
             self.options['mod_dir'] = [v]
         else:
             self.options['mod_dir'] = v
@@ -129,7 +129,7 @@ class ChopLib(Thread):
 
     @ext_dir.setter
     def ext_dir(self, v):
-        if isinstance(v, str):
+        if isinstance(v, basestring):
             self.options['ext_dir'] = [v]
         else:
             self.options['ext_dir'] = v
@@ -141,7 +141,7 @@ class ChopLib(Thread):
 
     @base_dir.setter
     def base_dir(self, v):
-        if isinstance(v,str):
+        if isinstance(v, basestring):
             self.options['base_dir'] = [v]
         else:
             self.options['base_dir'] = v


### PR DESCRIPTION
This allows us to assign unicode strings with these properties.

Prior to this, if you passed a unicode string in it would be split as
if it were a list.
