### PR TITLE
Improve lznt1 processing

### DIFF
--- a/ext_libs/lznt1.py
+++ b/ext_libs/lznt1.py
@@ -55,7 +55,7 @@ def _dCompressBlock(x):
                     u += x[0]
                     x = x[1:]
                 else:
-                    pt = unpack_from('H', x)[0]
+                    pt = unpack_from('<H', x)[0]
                     pt = pt & 0xffff
                     #print "PT = %x" % pt
                     i = (len(u)-1)  # Current Pos
@@ -97,7 +97,8 @@ def dCompressBuf(blob):
             hdr = blob[0:2]
             blob = blob[2:]
 
-            length = struct.unpack('H', hdr)[0]
+            length = struct.unpack('<H', hdr)[0]
+            compressed = ((length&0x8000) == (0x8000))
             length &= 0xfff
             length += 1
             if length > len(blob):
@@ -106,7 +107,10 @@ def dCompressBuf(blob):
             else:
                 y = blob[:length]
                 blob = blob[length:]
-                unc += _dCompressBlock(y)
+                if(compressed):
+                    unc += _dCompressBlock(y)
+                else:
+                    unc +=y
         except:
             good = False
 


### PR DESCRIPTION
change the unpacking to "<H".
change the algorithm to work correctly for blocks that are not compressed as indicated by the first bit in the header.