### PR TITLE
Fix for UnboundLocalError

### DIFF
--- a/modules/heartbleed_payloads.py
+++ b/modules/heartbleed_payloads.py
@@ -79,9 +79,9 @@ def taste(tcp):
 
 def handleStream(tcp):
     ((src, sport), (dst, dport)) = parse_addr(tcp)
+    count = tcp.client.count_new
     if tcp.client.count_new > 0:
         data = tcp.client.data[:tcp.client.count_new]
-        count = tcp.client.count_new
         if tcp.stream_data['dump']:
             chop.tsprnt("%s:%s -> %s:%s %i bytes" % (src, sport, dst, dport, count,))
             chop.prnt(hexdump(data))


### PR DESCRIPTION
Here was the traceback for the error: 

    Exception in module heartbleed_payloads -- Traceback: 
    Traceback (most recent call last):
      File "/..../chopshop/shop/ChopNids.py", line 566, in handleTcpStreams
        output = code.handleStream(tcpd)
      File "/..../chopshop/modules/heartbleed_payloads.py", line 93, in handleStream
        tcp.discard(count)
    UnboundLocalError: local variable 'count' referenced before assignment

This PR implements a simple fix. Will close #50 in favor of this PR.