### PR TITLE
Add Docker-ization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM debian:jessie
+
+MAINTAINER blacktop, https://github.com/blacktop
+
+# Copy source code to tmp folder
+COPY . /tmp
+RUN chmod -R 755 /tmp
+
+# Install ChopShop Required Dependencies
+RUN buildDeps='apt-utils \
+                autoconf \
+                automake \
+                build-essential \
+                git-core \
+                libemu-dev \
+                libmagic-dev \
+                libpcre3-dev \
+                libssl-dev \
+                python-dev \
+                python-setuptools' \
+  && set -x \
+  && echo "[INFO] Installing Dependancies..." \
+  && apt-get -q update \
+  && apt-get install -y $buildDeps \
+                        ca-certificates \
+                        libpcap-dev \
+                        libpcre3 \
+                        libtool \
+                        python \
+                        python-yara \
+                        swig \
+                        yara --no-install-recommends \
+  && easy_install pymongo \
+                  M2Crypto \
+                  pycrypto \
+                  dnslib \
+  && echo "[INFO] Installing Modules..." \
+  && cd /tmp \
+  && docker/install/pynids.sh \
+  && docker/install/htpy.sh \
+  && docker/install/yaraprocessor.sh \
+  && docker/install/pylibemu.sh \
+  && echo "[INFO] Installing ChopShop..." \
+  && make \
+  && make install \
+  && echo "[INFO] Remove Build Dependancies..." \
+  && apt-get autoremove --purge -y $buildDeps \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+VOLUME ["/pcap"]
+WORKDIR /pcap
+
+ENTRYPOINT ["/usr/local/bin/chopshop"]
+
+CMD ["-h"]

--- a/docker/chopshop.cfg
+++ b/docker/chopshop.cfg
@@ -1,0 +1,12 @@
+[Directories]
+base_dir = /usr/local/libexec/chopshop,/usr/local/bin
+
+[General]
+stdout = True
+modtree = False
+modinfo = False
+aslist = False
+fileout = output/%N/%N-%T.txt
+longrun = False
+GMT = False
+gui = False

--- a/docker/docker.md
+++ b/docker/docker.md
@@ -1,0 +1,107 @@
+ChopShop Dockerfile
+==================
+
+This repository contains a **Dockerfile** of [ChopShop](https://github.com/MITRECND/chopshop) for [Docker](https://www.docker.io/)'s [trusted build](https://index.docker.io/u/blacktop/chopshop/) published to the public [Docker Registry](https://index.docker.io/).
+
+### Dependencies
+* [debian:jessie](https://index.docker.io/_/debian/)
+
+### Image Size
+[![](https://badge.imagelayers.io/blacktop/chopshop:latest.svg)](https://imagelayers.io/?images=blacktop/chopshop:latest 'Get your own badge on imagelayers.io')
+
+### Image Tags
+```bash
+$ docker images
+
+REPOSITORY          TAG                 IMAGE ID           VIRTUAL SIZE
+blacktop/chopshop   latest              1df35766838d       262.3 MB
+```
+
+### Installation
+
+1. Install [Docker](://www.docker.io/).
+
+2. Download [trusted build](://index.docker.io/u/blacktop/chopshop/) from public [Docker Registry](://index.docker.io/): `docker pull blacktop/chopshop`
+
+#### Alternatively, build an image from Dockerfile
+```bash
+$ docker build -t blacktop/chopshop github.com/blacktop/docker-chopshop
+```
+### Usage
+```bash
+$ docker run -i -t -v /path/to/folder/pcap:/pcap:rw blacktop/chopshop -f my.pcap "http | http_extractor"
+```
+#### Output:
+```
+{
+  "request": {
+    "protocol": "HTTP/1.1",
+    "uri": {
+      "path": "/capabilities/cybersecurity/overview/cybersecurity-blog/an-introduction-to-chopshop-network-protocol",
+      "port_number": -1
+    },
+    "headers": {
+      "Host": "www.mitre.org",
+      "Connection": "Keep-Alive",
+      "Accept": "*/*",
+      "User-Agent": "Wget/1.15 (linux-gnu)"
+    },
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "body": "base64data",
+    "body_encoding": "base64",
+    "body_hash": "737203915c5f14da7f8b9c057678adfe",
+    "headers": {
+      "X-Request-ID": "v-334516c-565b-1224-b459-1232345469ec",
+      "X-Varnish": "5670865685 1569753878",
+      "X-Drupal-Cache": "MISS",
+      "X-Cache": "HIT",
+      "Content-Language": "en",
+      "Transfer-Encoding": "chunked",
+      "Age": "2342",
+      "Expires": "Sun, 19 Nov 1978 05:00:00 GMT",
+      "Vary": "Cookie,Accept-Encoding",
+      "X-AH-Environment": "prod",
+      "Server": "nginx",
+      "Last-Modified": "Mon, 11 Oct 2014 01:49:48 +0000",
+      "Connection": "keep-alive",
+      "Etag": "14145343481-1",
+      "Link": "<http://www.mitre.org/node/14985>; rel=shortlink,<http://www.mitre.org/capabilities/cybersecurity/overview/cybersecurity-blog/an-introduction-to-chopshop-network-protocol>; rel=canonical",
+      "Cache-Control": "public, max-age=3600",
+      "Date": "Mon, 13 Oct 2014 02:28:50 GMT",
+      "X-Cache-Hits": "4",
+      "Content-Type": "text/html; charset=utf-8",
+      "Via": "1.1 varnish",
+      "X-Generator": "Drupal 7 (http://drupal.org)"
+    }
+  }
+}
+```
+
+### To Run on OSX
+ - Install [Homebrew](http://brew.sh)
+
+```bash
+$ brew install caskroom/cask/brew-cask
+$ brew cask install virtualbox
+$ brew install docker
+$ brew install docker-machine
+$ docker-machine create --driver virtualbox dev
+$ eval $(docker-machine env dev)
+```
+Add the following to your bash or zsh profile
+
+```bash
+alias chopshop='docker run -it --rm -v `pwd`:/pcap:rw blacktop/chopshop $@'
+```
+#### Usage
+
+```bash
+chopshop -f malware.pcap "(dns, icmp) | malware_detector"
+```
+
+### Todo
+- [x] Install/Run ChopShop
+- [ ] Add MongoDB

--- a/docker/install/htpy.sh
+++ b/docker/install/htpy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+
+git clone --recursive git://github.com/MITRECND/htpy
+
+cd htpy
+
+python setup.py build
+python setup.py install

--- a/docker/install/pylibemu.sh
+++ b/docker/install/pylibemu.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -x
+
+git clone git://git.carnivore.it/libemu.git
+
+cd libemu
+
+autoreconf -v -i
+
+./configure --enable-python-bindings --prefix=/opt/libemu
+make install
+echo "/opt/libemu/lib/" >> /etc/ld.so.conf.d/libemu.conf
+ldconfig
+
+git clone git://github.com/buffer/pylibemu.git
+
+cd pylibemu
+
+python setup.py build
+python setup.py install

--- a/docker/install/pynids.sh
+++ b/docker/install/pynids.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -x
+
+git clone --recursive git://github.com/MITRECND/pynids
+
+cd pynids
+
+python setup.py build
+python setup.py install

--- a/docker/install/yaraprocessor.sh
+++ b/docker/install/yaraprocessor.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -x
+
+git clone git://github.com/MITRECND/yaraprocessor.git
+
+cd yaraprocessor
+
+python setup.py install


### PR DESCRIPTION
You will need to replace `blacktop` in `docker/docker.md` with whatever name you choose in the Docker Hub.  Other possible improvements would be to create a `chopshop` user and run as that user to avoid running as root inside the container.  However, docker is going to add namespace isolation soon and then root inside the container won’t be root outside the container.  Let me know if you would like me to create a second pull request to add this.